### PR TITLE
Added event.preventDefault to lastclick and firstclick

### DIFF
--- a/scripts/resources/jquery.events.js
+++ b/scripts/resources/jquery.events.js
@@ -165,6 +165,9 @@
 				$el.data('lastclick-timeout',timeout);
 			};
 			var check = function(event){
+				// Don't allow default actions when we're using lastclick
+                		event.preventDefault();
+                		
 				// Fetch
 				var Me = this;
 				clear.call(Me);
@@ -239,6 +242,10 @@
 					event.type = 'firstclick';
 					$.event.handle.apply(Me, [event])
 				}
+				// Don't allow default actions on the remaining clicks when we're using firstclick
+                		else {
+                    			event.preventDefault();
+                		}
 				// Handle Timeout for when All Clicks are Completed
 				var timeout = setTimeout(function(){
 					// Clear Timeout


### PR DESCRIPTION
Using event.preventDefault on the remaining clicks of the firstclick event and all lastclick events since there's no point in allowing default actions on them.

If I for example use the firstclick handler to to prevent multiple ajax requests I would have a event.preventDefault in it. But it would only be executed for the firstclick event, not the remaining click events. 

Of course it could be solved by using something like this.

```
$el.on("firstclick click", function (e) {
    e.preventDefault();
    if (e.type == "firstclick") {
        // Do stuff
    }
);
```

But that doesn't seem like the right way to do it.
